### PR TITLE
Fix card hover animation causing unwanted flickering effect

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -692,20 +692,8 @@ pre {
 }
 
 /* Animations */
-@keyframes fadeIn {
-    from { 
-        opacity: 0; 
-        transform: translateY(20px); 
-    }
-    to { 
-        opacity: 1; 
-        transform: translateY(0); 
-    }
-}
+/* Removed fadeIn animation - no longer needed */
 
-.card:hover {
-    animation: fadeIn 0.3s ease;
-}
 
 /* Interactive Map */
 .location-marker {


### PR DESCRIPTION
- Remove fadeIn animation from .card:hover which was causing quick flickering
- Remove unused @keyframes fadeIn animation definition
- Preserve existing smooth hover effects (translateY, box-shadow, border-color)

This fixes the issue where hovering over any card would trigger an unnecessary fadeIn animation that made the cards appear to flicker.

🤖 Generated with [Claude Code](https://claude.ai/code)